### PR TITLE
Fix ONNX output name mismatch

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -922,7 +922,8 @@ async function computeFlowsForState(game) {
   const results = await ortSession.run(feeds);
 
   // 4) Extract the raw log-flows (shape [1,40] → we ignore batch dim)
-  const logFdata = results.logF.data; // Float32Array length 40
+  // output tensor is named "logits" in the exported ONNX model
+  const logFdata = results.logits.data; // Float32Array length 40
 
   // 5) Map back into action_key → log-flow dictionary
   const flows = {};


### PR DESCRIPTION
## Summary
- adjust `main.js` to use the correct output tensor name from gfn.onnx

## Testing
- `pre-commit` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68581439693c832c87d815376c501253