### PR TITLE
Show full flow in demo

### DIFF
--- a/static/flow_conservation.js
+++ b/static/flow_conservation.js
@@ -111,7 +111,8 @@
         .attr('text-anchor', 'middle')
         .attr('fill', '#000')
         .attr('font-size', 12)
-        .text('Flow: ' + a.flow.toFixed(1));
+        // show the precise flow value passed from main.js
+        .text('Flow: ' + a.flow);
 
       drawMini(svg, boardsData.results[i].board,
                xResult, y - BH_ROOT/2,


### PR DESCRIPTION
## Summary
- display exact flow value in `static/flow_conservation.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c31f26db0832cb984ea2dc6c888d6