### PR TITLE
Fix arrowhead alignment in molecule flow

### DIFF
--- a/static/molecule_flow.js
+++ b/static/molecule_flow.js
@@ -152,14 +152,14 @@ function drawSankey(selector, rawScores) {
     .attr('id','arrow')
     .attr('viewBox', `0 0 ${CFG2.arrowSize} ${CFG2.arrowSize}`)
     .attr('markerUnits','userSpaceOnUse')
-    .attr('markerWidth',CFG2.arrowSize)
-    .attr('markerHeight',CFG2.arrowSize)
-    .attr('refX', 0)
+    .attr('markerWidth', CFG2.arrowSize)
+    .attr('markerHeight', CFG2.arrowSize)
+    .attr('refX', CFG2.arrowSize)
     .attr('refY', CFG2.arrowSize / 2)
     .attr('orient','auto')
     .append('path')
-      .attr('d', `M0,${CFG2.arrowSize/2} L${CFG2.arrowSize},0 L${CFG2.arrowSize},${CFG2.arrowSize} Z`)
-      .attr('fill','#000');
+      .attr('d', `M0,0 L0,${CFG2.arrowSize} L${CFG2.arrowSize},${CFG2.arrowSize/2} Z`)
+      .attr('fill', '#000');
 
   // draw links
   svg.append('g').selectAll('path')


### PR DESCRIPTION
## Summary
- ensure marker refX uses the arrow width
- draw arrow path pointing forward

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd3536be0832c995694f47a757ba3